### PR TITLE
Fix UTF-8 panic in truncate_smart

### DIFF
--- a/core/src/handoff/mod.rs
+++ b/core/src/handoff/mod.rs
@@ -175,11 +175,17 @@ fn truncate_smart(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
     }
-    // Try to cut at a line boundary
-    let cut = &s[..max];
+    // Find a valid UTF-8 char boundary at or before `max` to avoid panicking
+    // on multi-byte characters (e.g., non-ASCII file paths, emoji, CJK text).
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    // Try to cut at a line boundary for cleaner output
+    let cut = &s[..end];
     if let Some(last_nl) = cut.rfind('\n') {
         format!("{}\n[...truncated]", &s[..last_nl])
     } else {
-        format!("{}...", &s[..max])
+        format!("{}...", cut)
     }
 }


### PR DESCRIPTION
## Summary

- Fix a panic in `truncate_smart()` in `core/src/handoff/mod.rs` where `&s[..max]` crashes if `max` falls in the middle of a multi-byte UTF-8 character (emoji, CJK text, non-ASCII file paths in error messages, etc.)
- Adds a char boundary check before slicing, matching the safe pattern already used by `build_handoff()` in the same file

## Details

The `truncate_smart` function is used to truncate error messages and diff summaries in handoff packages. If these contain multi-byte UTF-8 characters and the truncation point lands mid-character, Rust panics with `byte index is not a char boundary`. This is a real risk since error messages and file paths from international users or projects with emoji in paths will trigger it.

## Test plan

- [ ] Verify the fix compiles: `cargo build --release` in `core/`
- [ ] Confirm truncation still works correctly for ASCII-only strings
- [ ] Test with strings containing multi-byte chars (e.g., emoji, CJK) at truncation boundaries

Generated with [Claude Code](https://claude.com/claude-code)