### PR TITLE
Handle API errors gracefully in agent adapters

### DIFF
--- a/core/src/agents/gemini.rs
+++ b/core/src/agents/gemini.rs
@@ -86,9 +86,33 @@ impl Agent for GeminiAgent {
             }]
         });
 
-        let resp = ureq::post(&url)
+        let resp = match ureq::post(&url)
             .set("Content-Type", "application/json")
-            .send_json(&body)?;
+            .send_json(&body)
+        {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(code, resp)) => {
+                let error_body = resp.into_string().unwrap_or_default();
+                let api_msg = serde_json::from_str::<serde_json::Value>(&error_body)
+                    .ok()
+                    .and_then(|v| v.get("error").and_then(|e| e.get("message")).and_then(|m| m.as_str()).map(String::from))
+                    .unwrap_or(error_body);
+                return Ok(HandoffResult {
+                    agent: "gemini".into(),
+                    success: false,
+                    message: format!("Gemini API error (HTTP {}): {}", code, api_msg),
+                    handoff_file: None,
+                });
+            }
+            Err(ureq::Error::Transport(t)) => {
+                return Ok(HandoffResult {
+                    agent: "gemini".into(),
+                    success: false,
+                    message: format!("Gemini API unreachable: {}", t),
+                    handoff_file: None,
+                });
+            }
+        };
 
         let resp_json: serde_json::Value = resp.into_json()?;
 

--- a/core/src/agents/ollama.rs
+++ b/core/src/agents/ollama.rs
@@ -57,9 +57,33 @@ impl Agent for OllamaAgent {
             "stream": false
         });
 
-        let resp = ureq::post(&url)
+        let resp = match ureq::post(&url)
             .set("Content-Type", "application/json")
-            .send_json(&body)?;
+            .send_json(&body)
+        {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(code, resp)) => {
+                let error_body = resp.into_string().unwrap_or_default();
+                let api_msg = serde_json::from_str::<serde_json::Value>(&error_body)
+                    .ok()
+                    .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+                    .unwrap_or(error_body);
+                return Ok(HandoffResult {
+                    agent: "ollama".into(),
+                    success: false,
+                    message: format!("Ollama API error (HTTP {}): {}", code, api_msg),
+                    handoff_file: None,
+                });
+            }
+            Err(ureq::Error::Transport(t)) => {
+                return Ok(HandoffResult {
+                    agent: "ollama".into(),
+                    success: false,
+                    message: format!("Ollama unreachable: {}", t),
+                    handoff_file: None,
+                });
+            }
+        };
 
         let resp_json: serde_json::Value = resp.into_json()?;
         let text = resp_json.get("response").and_then(|r| r.as_str()).unwrap_or("(no response)");

--- a/core/src/agents/openai.rs
+++ b/core/src/agents/openai.rs
@@ -59,10 +59,34 @@ impl Agent for OpenAIAgent {
             "max_tokens": 4096
         });
 
-        let resp = ureq::post("https://api.openai.com/v1/chat/completions")
+        let resp = match ureq::post("https://api.openai.com/v1/chat/completions")
             .set("Authorization", &format!("Bearer {api_key}"))
             .set("Content-Type", "application/json")
-            .send_json(&body)?;
+            .send_json(&body)
+        {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(code, resp)) => {
+                let error_body = resp.into_string().unwrap_or_default();
+                let api_msg = serde_json::from_str::<serde_json::Value>(&error_body)
+                    .ok()
+                    .and_then(|v| v.get("error").and_then(|e| e.get("message")).and_then(|m| m.as_str()).map(String::from))
+                    .unwrap_or(error_body);
+                return Ok(HandoffResult {
+                    agent: "openai".into(),
+                    success: false,
+                    message: format!("OpenAI API error (HTTP {}): {}", code, api_msg),
+                    handoff_file: None,
+                });
+            }
+            Err(ureq::Error::Transport(t)) => {
+                return Ok(HandoffResult {
+                    agent: "openai".into(),
+                    success: false,
+                    message: format!("OpenAI API unreachable: {}", t),
+                    handoff_file: None,
+                });
+            }
+        };
 
         let resp_json: serde_json::Value = resp.into_json()?;
         let text = resp_json


### PR DESCRIPTION
## Summary

- **Gemini, OpenAI, and Ollama agents** now catch `ureq::Error::Status` (HTTP 4xx/5xx) and extract the actual API error message from the response body instead of propagating an opaque Rust error
- **Transport errors** (network unreachable, DNS failure, connection refused) are also caught and reported with clear messages
- Errors return `HandoffResult { success: false, message: "..." }` instead of bubbling up via `?`, so the TUI can display the failure gracefully rather than crashing

### Before
```
Error: https://api.openai.com/v1/chat/completions: status code 401
```

### After
```
OpenAI API error (HTTP 401): Incorrect API key provided: sk-1234****. You can find your API key at https://platform.openai.com/account/api-keys.
```

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Test with an invalid Gemini API key and confirm the error message is extracted from the response
- [ ] Test with an invalid OpenAI API key and confirm the error message is extracted
- [ ] Test with Ollama not running and confirm transport error is reported
- [ ] Test with valid keys to confirm success path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)