### PR TITLE
Add Windows and Linux support

### DIFF
--- a/core/src/agents/aider.rs
+++ b/core/src/agents/aider.rs
@@ -1,7 +1,7 @@
 //! Aider agent adapter — launches the aider TUI interactively.
 //! https://github.com/paul-gauthier/aider
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, HandoffResult};
 use anyhow::Result;
 use std::process::Command;
@@ -16,22 +16,13 @@ impl AiderAgent {
             model: model.unwrap_or("sonnet").to_string(),
         }
     }
-
-    fn find_binary() -> Option<String> {
-        let output = Command::new("which").arg("aider").output().ok()?;
-        if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        } else {
-            None
-        }
-    }
 }
 
 impl Agent for AiderAgent {
     fn name(&self) -> &str { "aider" }
 
     fn check_available(&self) -> AgentStatus {
-        match Self::find_binary() {
+        match find_binary("aider") {
             Some(path) => AgentStatus {
                 name: "aider".into(),
                 available: true,
@@ -50,7 +41,7 @@ impl Agent for AiderAgent {
     }
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
-        let binary = Self::find_binary().unwrap_or("aider".into());
+        let binary = find_binary("aider").unwrap_or("aider".into());
         let tmp = std::env::temp_dir().join("relay_handoff.md");
         std::fs::write(&tmp, handoff_prompt)?;
 

--- a/core/src/agents/claude.rs
+++ b/core/src/agents/claude.rs
@@ -1,7 +1,7 @@
 //! Claude CLI agent — starts a new Claude Code session with full context.
 //! Useful when the rate limit resets or you have a second subscription.
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, HandoffResult};
 use anyhow::Result;
 use std::process::Command;
@@ -11,22 +11,13 @@ pub struct ClaudeAgent;
 
 impl ClaudeAgent {
     pub fn new() -> Self { Self }
-
-    fn find_binary() -> Option<String> {
-        let output = Command::new("which").arg("claude").output().ok()?;
-        if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        } else {
-            None
-        }
-    }
 }
 
 impl Agent for ClaudeAgent {
     fn name(&self) -> &str { "claude" }
 
     fn check_available(&self) -> AgentStatus {
-        match Self::find_binary() {
+        match find_binary("claude") {
             Some(path) => AgentStatus {
                 name: "claude".into(),
                 available: true,
@@ -45,7 +36,7 @@ impl Agent for ClaudeAgent {
     }
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
-        let binary = Self::find_binary().unwrap_or("claude".into());
+        let binary = find_binary("claude").unwrap_or("claude".into());
         let tmp = std::env::temp_dir().join("relay_handoff.md");
         std::fs::write(&tmp, handoff_prompt)?;
 

--- a/core/src/agents/codex.rs
+++ b/core/src/agents/codex.rs
@@ -1,7 +1,7 @@
 //! Codex CLI agent adapter.
 //! Launches `codex` (OpenAI Codex CLI) as a subprocess with the handoff prompt.
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, CodexConfig, HandoffResult};
 use anyhow::Result;
 use std::process::Command;
@@ -18,25 +18,13 @@ impl CodexAgent {
             model: config.model.clone(),
         }
     }
-
-    fn find_binary(&self) -> Option<String> {
-        // Check if binary exists in PATH
-        let output = Command::new("which")
-            .arg(&self.binary)
-            .output()
-            .ok()?;
-        if output.status.success() {
-            return Some(String::from_utf8_lossy(&output.stdout).trim().to_string());
-        }
-        None
-    }
 }
 
 impl Agent for CodexAgent {
     fn name(&self) -> &str { "codex" }
 
     fn check_available(&self) -> AgentStatus {
-        match self.find_binary() {
+        match find_binary(&self.binary) {
             Some(path) => {
                 // Try to get version
                 let version = Command::new(&path)
@@ -63,7 +51,7 @@ impl Agent for CodexAgent {
     }
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
-        let binary = self.find_binary().unwrap_or(self.binary.clone());
+        let binary = find_binary(&self.binary).unwrap_or(self.binary.clone());
 
         // Write handoff to a temp file for reference
         let tmp = std::env::temp_dir().join("relay_handoff.md");

--- a/core/src/agents/copilot.rs
+++ b/core/src/agents/copilot.rs
@@ -1,6 +1,6 @@
 //! GitHub Copilot CLI agent adapter.
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, HandoffResult};
 use anyhow::Result;
 use std::process::Command;
@@ -10,22 +10,13 @@ pub struct CopilotAgent;
 
 impl CopilotAgent {
     pub fn new() -> Self { Self }
-
-    fn find_binary() -> Option<String> {
-        let output = Command::new("which").arg("copilot").output().ok()?;
-        if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        } else {
-            None
-        }
-    }
 }
 
 impl Agent for CopilotAgent {
     fn name(&self) -> &str { "copilot" }
 
     fn check_available(&self) -> AgentStatus {
-        match Self::find_binary() {
+        match find_binary("copilot") {
             Some(path) => AgentStatus {
                 name: "copilot".into(),
                 available: true,
@@ -42,7 +33,7 @@ impl Agent for CopilotAgent {
     }
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
-        let binary = Self::find_binary().unwrap_or("copilot".into());
+        let binary = find_binary("copilot").unwrap_or("copilot".into());
         let tmp = std::env::temp_dir().join("relay_handoff.md");
         std::fs::write(&tmp, handoff_prompt)?;
 

--- a/core/src/agents/gemini.rs
+++ b/core/src/agents/gemini.rs
@@ -1,6 +1,6 @@
 //! Gemini agent adapter — uses the Gemini API.
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, GeminiConfig, HandoffResult};
 use anyhow::Result;
 
@@ -26,15 +26,13 @@ impl Agent for GeminiAgent {
 
     fn check_available(&self) -> AgentStatus {
         // First check if gemini CLI is available
-        if let Ok(output) = std::process::Command::new("which").arg("gemini").output() {
-            if output.status.success() {
-                return AgentStatus {
-                    name: "gemini".into(),
-                    available: true,
-                    reason: "Gemini CLI found in PATH".into(),
-                    version: None,
-                };
-            }
+        if find_binary("gemini").is_some() {
+            return AgentStatus {
+                name: "gemini".into(),
+                available: true,
+                reason: "Gemini CLI found in PATH".into(),
+                version: None,
+            };
         }
 
         match &self.api_key {
@@ -55,20 +53,18 @@ impl Agent for GeminiAgent {
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
         // Try Gemini CLI first
-        if let Ok(output) = std::process::Command::new("which").arg("gemini").output() {
-            if output.status.success() {
-                let mut child = std::process::Command::new("gemini")
-                    .current_dir(project_dir)
-                    .arg(handoff_prompt)
-                    .spawn()?;
-                let _ = child.wait();
-                return Ok(HandoffResult {
-                    agent: "gemini".into(),
-                    success: true,
-                    message: "Gemini CLI launched with handoff context".into(),
-                    handoff_file: None,
-                });
-            }
+        if find_binary("gemini").is_some() {
+            let mut child = std::process::Command::new("gemini")
+                .current_dir(project_dir)
+                .arg(handoff_prompt)
+                .spawn()?;
+            let _ = child.wait();
+            return Ok(HandoffResult {
+                agent: "gemini".into(),
+                success: true,
+                message: "Gemini CLI launched with handoff context".into(),
+                handoff_file: None,
+            });
         }
 
         // Fall back to API

--- a/core/src/agents/mod.rs
+++ b/core/src/agents/mod.rs
@@ -9,6 +9,20 @@ pub mod opencode;
 
 use crate::{AgentStatus, Config, HandoffResult};
 use anyhow::Result;
+use std::process::Command;
+
+/// Cross-platform binary finder: uses `where` on Windows, `which` on Unix.
+pub fn find_binary(name: &str) -> Option<String> {
+    let cmd = if cfg!(target_os = "windows") { "where" } else { "which" };
+    let output = Command::new(cmd).arg(name).output().ok()?;
+    if output.status.success() {
+        // `where` can return multiple lines; take the first
+        let out = String::from_utf8_lossy(&output.stdout);
+        Some(out.lines().next()?.trim().to_string())
+    } else {
+        None
+    }
+}
 
 /// Trait for all fallback agents.
 pub trait Agent {

--- a/core/src/agents/opencode.rs
+++ b/core/src/agents/opencode.rs
@@ -1,7 +1,7 @@
 //! OpenCode agent adapter — Go-based coding agent.
 //! https://github.com/opencode-ai/opencode
 
-use super::Agent;
+use super::{Agent, find_binary};
 use crate::{AgentStatus, HandoffResult};
 use anyhow::Result;
 use std::process::Command;
@@ -11,22 +11,13 @@ pub struct OpenCodeAgent;
 
 impl OpenCodeAgent {
     pub fn new() -> Self { Self }
-
-    fn find_binary() -> Option<String> {
-        let output = Command::new("which").arg("opencode").output().ok()?;
-        if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        } else {
-            None
-        }
-    }
 }
 
 impl Agent for OpenCodeAgent {
     fn name(&self) -> &str { "opencode" }
 
     fn check_available(&self) -> AgentStatus {
-        match Self::find_binary() {
+        match find_binary("opencode") {
             Some(path) => AgentStatus {
                 name: "opencode".into(),
                 available: true,
@@ -45,7 +36,7 @@ impl Agent for OpenCodeAgent {
     }
 
     fn execute(&self, handoff_prompt: &str, project_dir: &str) -> Result<HandoffResult> {
-        let binary = Self::find_binary().unwrap_or("opencode".into());
+        let binary = find_binary("opencode").unwrap_or("opencode".into());
         let tmp = std::env::temp_dir().join("relay_handoff.md");
         std::fs::write(&tmp, handoff_prompt)?;
 

--- a/core/src/capture/session.rs
+++ b/core/src/capture/session.rs
@@ -46,14 +46,18 @@ pub fn read_latest_session(project_dir: &Path) -> SessionInfo {
 }
 
 pub fn find_claude_project_dir(project_dir: &Path) -> Option<std::path::PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    let claude_projects = std::path::PathBuf::from(&home).join(".claude/projects");
+    let home_dir = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))?;
+    let claude_projects = std::path::PathBuf::from(home_dir).join(".claude/projects");
     if !claude_projects.exists() {
         return None;
     }
 
-    // Claude encodes: /Users/user/myproject -> -Users-user-myproject
-    let proj_str = project_dir.to_string_lossy().replace('/', "-");
+    // Claude encodes paths with / and \ as dashes: /Users/user/myproject -> -Users-user-myproject
+    let proj_str = project_dir
+        .to_string_lossy()
+        .replace('/', "-")
+        .replace('\\', "-");
     let candidate = claude_projects.join(&proj_str);
     if candidate.exists() {
         return Some(candidate);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -135,14 +135,19 @@ impl Config {
     }
 }
 
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir())
+}
+
 pub fn config_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    PathBuf::from(home).join(".relay/config.toml")
+    home_dir().join(".relay/config.toml")
 }
 
 pub fn data_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    PathBuf::from(home).join(".relay")
+    home_dir().join(".relay")
 }
 
 // ─── Core Types ──────────────────────────────────────────────────────────────

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -205,10 +205,55 @@ fn main() -> Result<()> {
                     eprintln!("  📋 Handoff copied to clipboard!");
                     eprintln!("  📄 Also saved: {}", handoff_path.display());
                 }
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(target_os = "windows")]
                 {
-                    eprintln!("  Clipboard not supported on this platform.");
-                    eprintln!("  📄 Saved to: {}", handoff_path.display());
+                    use std::process::{Command, Stdio};
+                    let mut child = Command::new("clip")
+                        .stdin(Stdio::piped())
+                        .spawn()?;
+                    if let Some(mut stdin) = child.stdin.take() {
+                        use std::io::Write;
+                        stdin.write_all(handoff_text.as_bytes())?;
+                    }
+                    child.wait()?;
+                    eprintln!("  📋 Handoff copied to clipboard!");
+                    eprintln!("  📄 Also saved: {}", handoff_path.display());
+                }
+                #[cfg(all(unix, not(target_os = "macos")))]
+                {
+                    use std::process::{Command, Stdio};
+                    // Try xclip first (X11), then wl-copy (Wayland)
+                    let clipboard_result = if let Ok(mut child) = Command::new("xclip")
+                        .arg("-selection")
+                        .arg("clipboard")
+                        .stdin(Stdio::piped())
+                        .spawn()
+                    {
+                        if let Some(mut stdin) = child.stdin.take() {
+                            use std::io::Write;
+                            let _ = stdin.write_all(handoff_text.as_bytes());
+                        }
+                        child.wait().ok()
+                    } else if let Ok(mut child) = Command::new("wl-copy")
+                        .stdin(Stdio::piped())
+                        .spawn()
+                    {
+                        if let Some(mut stdin) = child.stdin.take() {
+                            use std::io::Write;
+                            let _ = stdin.write_all(handoff_text.as_bytes());
+                        }
+                        child.wait().ok()
+                    } else {
+                        None
+                    };
+
+                    if clipboard_result.is_some() {
+                        eprintln!("  📋 Handoff copied to clipboard!");
+                        eprintln!("  📄 Also saved: {}", handoff_path.display());
+                    } else {
+                        eprintln!("  Clipboard tools not available (xclip or wl-copy required)");
+                        eprintln!("  📄 Saved to: {}", handoff_path.display());
+                    }
                 }
                 return Ok(());
             }

--- a/core/tests/history_test.rs
+++ b/core/tests/history_test.rs
@@ -20,6 +20,10 @@ fn history_finds_handoff_files() {
         relay_dir.join("handoff_20260405_180000.md"),
         "## CURRENT TASK\n\nFix the bug\n\n  Target agent   : codex\n",
     ).unwrap();
+
+    // Add small delay to ensure different modification times
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
     std::fs::write(
         relay_dir.join("handoff_20260405_190000.md"),
         "## CURRENT TASK\n\nDeploy the app\n\n  Target agent   : gemini\n",
@@ -27,7 +31,7 @@ fn history_finds_handoff_files() {
 
     let entries = relay::history::list_handoffs(&dir, 10).unwrap();
     assert_eq!(entries.len(), 2);
-    // Newest first
+    // Newest first (sorted by file modification time)
     assert!(entries[0].timestamp.contains("19:00"));
 
     std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
- Fix home directory detection to work on Windows (USERPROFILE env var)
- Add cross-platform binary finder for agent detection (where vs which)
- Add clipboard support for Windows (clip) and Linux (xclip/wl-copy)
- Fix flaky history test that failed on different systems

## What does this PR do?

Relay was only working reliably on macOS. This PR fixes all the platform-specific issues so it works properly on Windows, Linux, and macOS.

**Home Directory Issue**
On Windows, the app was trying to read the `HOME` environment variable which doesn't exist. It fell back to `/tmp` which isn't valid on Windows. Now it checks `HOME` first (Unix systems), then `USERPROFILE` (Windows), and finally falls back to the system temp directory. Claude project path lookups also now handle Windows backslashes correctly.

**Agent Detection Broken on Windows**
All CLI agents (codex, claude, aider, copilot, gemini, opencode) use the `which` command to find binaries. The `which` command doesn't exist on Windows. Added a shared `find_binary()` helper that uses `where` on Windows and `which` on Unix. All 6 agent files now use this instead of their own duplicate code.

**No Clipboard Support on Windows/Linux**
The clipboard feature only worked on macOS with `pbcopy`. Added Windows support using the `clip` command, and Linux support using `xclip` (X11) or `wl-copy` (Wayland).

**Flaky Test**
The history test was creating files at the same time but expecting them to be sorted by modification time. Added a small delay between file creations to make the test deterministic.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New agent adapter
- [ ] Documentation
- [ ] Refactor

## Checklist

- [x] `cargo check` passes
- [x] `cargo test` passes (all 32 tests)
- [x] `cargo clippy` passes
- [ ] Updated README if needed
