### PR TITLE
feat: chain fallback for named agent handoffs

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -69,6 +69,10 @@ enum Commands {
         /// Target a specific session by ID (or prefix). Use 'relay sessions' to list.
         #[arg(long)]
         session: Option<String>,
+
+        /// Disable chain fallback when using --to (don't try other agents on failure)
+        #[arg(long)]
+        no_chain: bool,
     },
 
     /// List available Claude Code sessions
@@ -212,7 +216,7 @@ fn main() -> Result<()> {
         // ═══════════════════════════════════════════════════════════════
         // HANDOFF
         // ═══════════════════════════════════════════════════════════════
-        Commands::Handoff { to, deadline, dry_run, force, turns, include, clipboard, template, session } => {
+        Commands::Handoff { to, deadline, dry_run, force, turns, include, clipboard, template, session, no_chain } => {
             if !cli.json {
                 tui::print_banner();
             }
@@ -432,7 +436,7 @@ fn main() -> Result<()> {
             let sp = tui::step(3, 3, &format!("Launching {}...", target_name));
 
             let result = if to.is_some() {
-                agents::handoff_to_named(&config, &target_name, &handoff_text, &project_dir.to_string_lossy())
+                agents::handoff_to_named(&config, &target_name, &handoff_text, &project_dir.to_string_lossy(), !no_chain)
             } else {
                 agents::handoff_to_first_available(&config, &handoff_text, &project_dir.to_string_lossy())
             }?;

--- a/core/src/replay.rs
+++ b/core/src/replay.rs
@@ -26,7 +26,7 @@ pub fn replay_handoff(
     }
 
     let result = if let Some(name) = agent_name {
-        crate::agents::handoff_to_named(config, name, &handoff_text, &project_dir)?
+        crate::agents::handoff_to_named(config, name, &handoff_text, &project_dir, true)?
     } else {
         crate::agents::handoff_to_first_available(config, &handoff_text, &project_dir)?
     };

--- a/core/tests/agents_test.rs
+++ b/core/tests/agents_test.rs
@@ -56,7 +56,7 @@ fn handoff_to_unavailable_fails_gracefully() {
         },
         agents: Default::default(),
     };
-    let result = agents::handoff_to_named(&config, "openai", "test", "/tmp").unwrap();
+    let result = agents::handoff_to_named(&config, "openai", "test", "/tmp", false).unwrap();
     assert!(!result.success);
     assert!(result.message.contains("not available"));
 }
@@ -67,7 +67,7 @@ fn handoff_to_unknown_agent_fails() {
         general: Default::default(),
         agents: Default::default(),
     };
-    let result = agents::handoff_to_named(&config, "doesnotexist", "test", "/tmp").unwrap();
+    let result = agents::handoff_to_named(&config, "doesnotexist", "test", "/tmp", false).unwrap();
     assert!(!result.success);
     assert!(result.message.contains("Unknown agent"));
 }


### PR DESCRIPTION
## Summary
- `relay handoff --to codex` now cascades to next agent if codex fails (both unavailable and execution failure)
- New `--no-chain` flag disables cascade (old behavior)
- `relay replay` also benefits from chain fallback
- Warning messages printed when falling back

## Test plan
- [x] `cargo check` compiles cleanly
- [x] All 62 tests pass
- [ ] `relay handoff --to nonexistent` cascades to first available
- [ ] `relay handoff --to nonexistent --no-chain` fails without cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)