### PR TITLE
Add Vscode Extension for chat panel handoff

### DIFF
--- a/vscode-extension/.eslintrc.json
+++ b/vscode-extension/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "rules": {
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/semi": "warn",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn"
+  }
+}

--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,0 +1,6 @@
+out
+dist
+node_modules
+*.vsix
+.DS_Store
+*.log

--- a/vscode-extension/DEVELOPMENT.md
+++ b/vscode-extension/DEVELOPMENT.md
@@ -1,0 +1,112 @@
+# Extension Development Guide
+
+## Project Structure
+
+```
+vscode-extension/
+├── src/
+│   ├── extension.ts          # Entry point
+│   ├── relayClient.ts        # CLI wrapper
+│   ├── commands/
+│   │   └── index.ts          # Command handlers
+│   ├── views/
+│   │   └── sessionPanel.ts   # Sidebar panel
+│   └── utils/
+├── package.json              # Extension manifest
+├── tsconfig.json             # TypeScript config
+└── README.md
+```
+
+## Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Watch for changes
+npm run watch
+
+# In VS Code: Press F5 to launch extension in debug mode
+```
+
+## Architecture
+
+**extension.ts** — Activation and setup
+- Initialize RelayClient
+- Register commands
+- Create status bar item
+- Set up auto-refresh
+
+**relayClient.ts** — Wraps relay CLI
+- Executes relay commands as subprocesses
+- Parses JSON output
+- Handles errors
+
+**commands/index.ts** — Command handlers
+- showStatus
+- handoff
+- copyHandoff
+- history
+- viewDiff
+
+**views/sessionPanel.ts** — Sidebar tree view
+- Displays session snapshot
+- Lists available agents
+- Updates on refresh
+
+## Adding a New Command
+
+1. Add command to `package.json` under `contributes.commands`
+2. Register handler in `commands/index.ts`:
+
+```typescript
+context.subscriptions.push(
+  vscode.commands.registerCommand('relay.newCommand', async () => {
+    try {
+      // Your code here
+      vscode.window.showInformationMessage('Done!');
+    } catch (error) {
+      vscode.window.showErrorMessage(`Error: ${error}`);
+    }
+  })
+);
+```
+
+## Debugging
+
+1. Press `F5` to launch in debug mode
+2. Set breakpoints in TypeScript files
+3. Use Debug Console for output
+4. Hot-reload: `npm run watch` in another terminal
+
+## Testing
+
+```bash
+# Manually test in debug extension window:
+# - Run commands from command palette (Cmd+Shift+P)
+# - Check sidebar panel updates
+# - Verify error messages display correctly
+```
+
+## Common Issues
+
+**"relay binary not found"**
+- Ensure relay is installed: `cargo install --path core`
+- Or set `relay.binaryPath` in settings
+
+**Panel doesn't show**
+- Check that relay binary is available
+- Reload VS Code window (Cmd+Shift+P → Developer: Reload Window)
+
+**Commands don't appear**
+- Rebuild: `npm run compile`
+- Reload VS Code
+
+## Publishing to VS Code Marketplace
+
+1. Install `vsce`: `npm install -g vsce`
+2. Get a personal access token
+3. Login: `vsce login relay`
+4. Publish: `vsce publish`
+
+See [VS Code Extension Publishing Guide](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,85 @@
+# Relay — VS Code Extension
+
+Manage Claude Code session handoffs directly in VS Code.
+
+## Features
+
+- 📋 **Session Panel** — View current task, git state, and available agents in the sidebar
+- 🤖 **One-Click Handoff** — Hand off to any available agent directly from VS Code
+- 📜 **History** — Browse past handoffs and what changed
+- 📊 **Diff Viewer** — See exactly what changed since last handoff
+- 🔄 **Auto-Refresh** — Session state updates automatically
+
+## Requirements
+
+- VS Code 1.84+
+- [Relay CLI](https://github.com/Manavarya09/relay) installed and in your PATH
+
+## Installation
+
+1. Clone the relay repository
+2. Navigate to `vscode-extension` folder
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Compile TypeScript:
+   ```bash
+   npm run compile
+   ```
+5. Open in VS Code and press `F5` to run the extension in debug mode
+
+## Configuration
+
+Edit `.vscode/settings.json` in your workspace:
+
+```json
+{
+  "relay.binaryPath": "relay",
+  "relay.autoRefreshInterval": 5000
+}
+```
+
+- `relay.binaryPath` — Path to relay binary (default: "relay")
+- `relay.autoRefreshInterval` — Auto-refresh interval in ms (0 to disable)
+
+## Commands
+
+- **Relay: Show Session Status** — Display current session details
+- **Relay: Handoff to Agent** — Select and handoff to an agent
+- **Relay: Copy Handoff to Clipboard** — Copy handoff prompt
+- **Relay: View Handoff History** — Browse past handoffs
+- **Relay: View Diff Since Handoff** — See what changed
+
+## Usage
+
+1. Open a project with a Claude Code session in VS Code
+2. Look for "Relay Session" panel in the Explorer sidebar
+3. Click the agent name to handoff, or use commands from the palette
+4. Session state updates automatically
+
+## Development
+
+```bash
+# Watch for changes
+npm run watch
+
+# Compile once
+npm run compile
+
+# Lint
+npm run lint
+```
+
+## Publishing
+
+```bash
+# Install vsce
+npm install -g vsce
+
+# Package
+vsce package
+
+# Publish to marketplace
+vsce publish
+```

--- a/vscode-extension/bun.lock
+++ b/vscode-extension/bun.lock
@@ -1,0 +1,280 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "relay-vscode",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.84.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@types/vscode": ["@types/vscode@1.110.0", "", {}, "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0" } }, "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@6.21.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/utils": "6.21.0", "debug": "^4.3.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "9.0.3", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" } }, "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@6.21.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@types/json-schema": "^7.0.12", "@types/semver": "^7.5.0", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "semver": "^7.5.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "eslint-visitor-keys": "^3.4.1" } }, "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
+
+    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,102 @@
+{
+  "name": "relay-vscode",
+  "displayName": "Relay — AI Agent Handoff",
+  "description": "Manage Claude Code session handoffs directly in VS Code",
+  "version": "0.1.0",
+  "publisher": "relay",
+  "engines": {
+    "vscode": "^1.84.0"
+  },
+  "categories": [
+    "Other",
+    "Productivity"
+  ],
+  "keywords": [
+    "claude",
+    "ai",
+    "agent",
+    "handoff",
+    "codex",
+    "gemini"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "relay.showStatus",
+        "title": "Relay: Show Session Status"
+      },
+      {
+        "command": "relay.handoff",
+        "title": "Relay: Handoff to Agent"
+      },
+      {
+        "command": "relay.history",
+        "title": "Relay: View Handoff History"
+      },
+      {
+        "command": "relay.copyHandoff",
+        "title": "Relay: Copy Handoff to Clipboard"
+      },
+      {
+        "command": "relay.viewDiff",
+        "title": "Relay: View Diff Since Handoff"
+      }
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "relay.sessionPanel",
+          "name": "Relay Session",
+          "when": "relay:hasRelayBinary"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "relay.sessionPanel",
+        "contents": "Relay binary not found.\nMake sure you have installed Relay:\n[Install Instructions](https://github.com/Manavarya09/relay#quick-start)"
+      }
+    ],
+    "statusBar": [
+      {
+        "id": "relay.status",
+        "alignment": "left",
+        "priority": 100
+      }
+    ],
+    "configuration": {
+      "title": "Relay",
+      "properties": {
+        "relay.binaryPath": {
+          "type": "string",
+          "default": "relay",
+          "description": "Path to the relay binary (default: uses PATH)"
+        },
+        "relay.autoRefreshInterval": {
+          "type": "number",
+          "default": 5000,
+          "description": "Auto-refresh session status interval in milliseconds (0 to disable)"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src --ext ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.84.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {}
+}

--- a/vscode-extension/src/agents/registry.ts
+++ b/vscode-extension/src/agents/registry.ts
@@ -1,0 +1,262 @@
+import * as vscode from 'vscode';
+
+export interface Agent {
+	id: string;
+	name: string;
+	autoTrigger: boolean;
+	launch: (handoffText: string) => Promise<void>;
+}
+
+const openChat = (text: string): Thenable<unknown> =>
+	vscode.commands.executeCommand('workbench.action.chat.open', { query: text });
+
+const withFallback = async (primary: () => Thenable<unknown>, fallback: () => Thenable<unknown>): Promise<void> => {
+	try { await primary(); } catch { await fallback(); }
+};
+
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+const clipboardLaunch = async (text: string, ...commands: string[]): Promise<void> => {
+	for (const cmd of commands) {
+		try {
+			await vscode.commands.executeCommand(cmd);
+			await delay(500);
+			break;
+		} catch { continue; }
+	}
+	await vscode.env.clipboard.writeText(text);
+	vscode.window.showInformationMessage('Handoff copied to clipboard — paste (Ctrl+V) in the chat input.');
+};
+
+export const AGENTS: Agent[] = [
+	{
+		id: 'github.copilot-chat',
+		name: 'GitHub Copilot Chat',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+	{
+		id: 'google.geminicodeassist',
+		name: 'Google Gemini Code Assist',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('geminicodeassist.startagent'),
+				() => Promise.resolve()
+			);
+			await delay(800);
+			await openChat(text);
+		},
+	},
+	{
+		id: 'anthropic.claude-code',
+		name: 'Claude Code',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('claude.newTask', text),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'saoudrizwan.claude-dev',
+		name: 'Cline',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('cline.newTask', text),
+				() => vscode.commands.executeCommand('cline.openInNewTab')
+			);
+		},
+	},
+	{
+		id: 'rooveterinaryinc.roo-cline',
+		name: 'Roo Code',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('roo-cline.newTask', text),
+				() => vscode.commands.executeCommand('roo-cline.openInNewTab')
+			);
+		},
+	},
+	{
+		id: 'sourcegraph.cody-ai',
+		name: 'Sourcegraph Cody',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('cody.chat.newEditorPanel'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'continue.continue',
+		name: 'Continue',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('continue.focusContinueInput', text),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'amazonwebservices.amazon-q-vscode',
+		name: 'Amazon Q',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('aws.amazonq.chat', text),
+				() => vscode.commands.executeCommand('aws.amazonq.focusChat')
+			);
+		},
+	},
+	{
+		id: 'codeium.codeium',
+		name: 'Codeium / Windsurf',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('codeium.openChat'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'tabnine.tabnine-vscode',
+		name: 'Tabnine',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('tabnine.chat.focus-input'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'codium.qodogen',
+		name: 'Qodo Gen',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('qodogen.openChat'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'openai.chatgpt',
+		name: 'Codex (OpenAI)',
+		autoTrigger: false,
+		launch: (text) => clipboardLaunch(text, 'chatgpt.openSidebar', 'chatgpt.newChat'),
+	},
+	{
+		id: 'blackboxapp.blackboxagent',
+		name: 'Blackbox AI Agent',
+		autoTrigger: false,
+		launch: (text) => clipboardLaunch(text, 'workbench.view.extension.blackboxai-dev-ActivityBar', 'blackbox.enableChatModeClicked'),
+	},
+	{
+		id: 'blackboxapp.blackbox',
+		name: 'Blackbox AI',
+		autoTrigger: false,
+		launch: (text) => clipboardLaunch(text, 'workbench.view.extension.blackboxai-dev-ActivityBar', 'blackbox.enableChatModeClicked'),
+	},
+	{
+		id: 'mistralai.mistral-code',
+		name: 'Mistral Code',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+	{
+		id: 'phind.phind',
+		name: 'Phind',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('phind.search', text),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'meshintelligentTechnologiesinc.pieces-vscode',
+		name: 'Pieces for Developers',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('pieces.copilot.open'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'supermaven.supermaven',
+		name: 'Supermaven',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+	{
+		id: 'bito.bito',
+		name: 'Bito AI',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+	{
+		id: 'huggingface.huggingface-vscode',
+		name: 'HuggingFace',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+	{
+		id: 'warm3snow.vscode-ollama',
+		name: 'Ollama',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('vscode-ollama.openChat'),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'lee2py.aider-composer',
+		name: 'Aider Composer',
+		autoTrigger: true,
+		launch: async (text) => {
+			await withFallback(
+				() => vscode.commands.executeCommand('aider-composer.newSession', text),
+				() => openChat(text)
+			);
+		},
+	},
+	{
+		id: 'kiteco.kite',
+		name: 'Kite',
+		autoTrigger: true,
+		launch: async (text) => { await openChat(text); },
+	},
+];
+
+function findExtension(id: string): vscode.Extension<unknown> | undefined {
+	const lower = id.toLowerCase();
+	return vscode.extensions.all.find(ext => ext.id.toLowerCase() === lower);
+}
+
+export function getInstalledAgents(): Agent[] {
+	return AGENTS.filter(agent => findExtension(agent.id) !== undefined);
+}
+
+export async function launchAgent(id: string, handoffText: string): Promise<void> {
+	const ext = findExtension(id);
+	if (ext && !ext.isActive) {
+		await ext.activate();
+	}
+	await vscode.env.clipboard.writeText(handoffText);
+
+	const agent = AGENTS.find(a => a.id === id);
+	await (agent ? agent.launch(handoffText) : openChat(handoffText));
+}

--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+import { RelayClient } from '../relayClient';
+
+export function registerCommands(
+	context: vscode.ExtensionContext,
+	relayClient: RelayClient
+): void {
+	// Helper to open terminal with command
+	function openTerminalWithCommand(command: string, name: string = 'Relay'): void {
+		const terminal = vscode.window.createTerminal(name);
+		terminal.sendText(command);
+		terminal.show();
+	}
+
+	// Handoff
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.handoff', async () => {
+			try {
+				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+				const agents = ['claude', 'codex', 'gemini', 'aider', 'copilot', 'opencode', 'ollama', 'openai'];
+
+				const selected = await vscode.window.showQuickPick(agents, {
+					placeHolder: 'Select agent to handoff to',
+					title: 'Relay Handoff',
+				});
+
+				if (!selected) {
+					return;
+				}
+
+				const command = relayClient.buildHandoffCommand(selected, projectDir);
+				openTerminalWithCommand(command, `Relay → ${selected}`);
+			} catch (error) {
+				vscode.window.showErrorMessage(`Error: ${error}`);
+			}
+		})
+	);
+
+	// Copy Handoff
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.copyHandoff', async () => {
+			try {
+				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const command = relayClient.buildCopyHandoffCommand(projectDir);
+				openTerminalWithCommand(command, 'Relay: Copy Handoff');
+			} catch (error) {
+				vscode.window.showErrorMessage(`Error: ${error}`);
+			}
+		})
+	);
+
+	// Status
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.showStatus', async () => {
+			try {
+				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const command = relayClient.buildStatusCommand(projectDir);
+				openTerminalWithCommand(command, 'Relay: Status');
+			} catch (error) {
+				vscode.window.showErrorMessage(`Error: ${error}`);
+			}
+		})
+	);
+
+	// History
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.history', async () => {
+			try {
+				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const command = relayClient.buildHistoryCommand(10, projectDir);
+				openTerminalWithCommand(command, 'Relay: History');
+			} catch (error) {
+				vscode.window.showErrorMessage(`Error: ${error}`);
+			}
+		})
+	);
+
+	// View Diff
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.viewDiff', async () => {
+			try {
+				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const command = relayClient.buildDiffCommand(projectDir);
+				openTerminalWithCommand(command, 'Relay: Diff');
+			} catch (error) {
+				vscode.window.showErrorMessage(`Error: ${error}`);
+			}
+		})
+	);
+}

--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -1,91 +1,97 @@
 import * as vscode from 'vscode';
 import { RelayClient } from '../relayClient';
+import { getInstalledAgents, launchAgent } from '../agents/registry';
 
-export function registerCommands(
-	context: vscode.ExtensionContext,
-	relayClient: RelayClient
-): void {
-	// Helper to open terminal with command
-	function openTerminalWithCommand(command: string, name: string = 'Relay'): void {
-		const terminal = vscode.window.createTerminal(name);
-		terminal.sendText(command);
-		terminal.show();
-	}
+interface AgentQuickPick extends vscode.QuickPickItem {
+	extensionId: string;
+}
 
-	// Handoff
+function openTerminal(command: string, name: string): void {
+	const terminal = vscode.window.createTerminal(name);
+	terminal.sendText(command);
+	terminal.show();
+}
+
+function projectDir(): string | undefined {
+	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+export function registerCommands(context: vscode.ExtensionContext, relayClient: RelayClient): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('relay.handoff', async () => {
-			try {
-				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			const agents = getInstalledAgents();
 
-				const agents = ['claude', 'codex', 'gemini', 'aider', 'copilot', 'opencode', 'ollama', 'openai'];
-
-				const selected = await vscode.window.showQuickPick(agents, {
-					placeHolder: 'Select agent to handoff to',
-					title: 'Relay Handoff',
-				});
-
-				if (!selected) {
-					return;
-				}
-
-				const command = relayClient.buildHandoffCommand(selected, projectDir);
-				openTerminalWithCommand(command, `Relay → ${selected}`);
-			} catch (error) {
-				vscode.window.showErrorMessage(`Error: ${error}`);
+			if (agents.length < 1) {
+				vscode.window.showWarningMessage('No agent extensions found. Install Copilot, Gemini, or similar.');
+				return;
 			}
+
+			const toItems = (list: ReturnType<typeof getInstalledAgents>): AgentQuickPick[] =>
+				list.map(a => ({
+					label: a.name,
+					extensionId: a.id,
+					description: a.autoTrigger ? 'Auto' : 'Clipboard',
+				}));
+
+			const from = await vscode.window.showQuickPick(toItems(agents), {
+				placeHolder: 'Handing off from...',
+				title: 'Relay Handoff (1/2)',
+			});
+			if (!from) { return; }
+
+			const to = await vscode.window.showQuickPick(
+				toItems(agents.filter(a => a.id !== from.extensionId)),
+				{
+					placeHolder: 'Hand off to...',
+					title: `Relay Handoff: ${from.label} → (2/2)`,
+				}
+			);
+			if (!to) { return; }
+
+			await vscode.window.withProgress(
+				{ location: vscode.ProgressLocation.Notification, title: `${from.label} → ${to.label}`, cancellable: false },
+				async (progress) => {
+					try {
+						progress.report({ message: 'Capturing session...' });
+						const result = await relayClient.getHandoffText(to.extensionId, projectDir());
+
+						const handoffWithContext = `[Handoff from ${from.label}]\n\n${result.handoff_text}`;
+
+						progress.report({ message: `Launching ${to.label}...` });
+						await launchAgent(to.extensionId, handoffWithContext);
+
+						vscode.window.showInformationMessage(
+							`Session handed off from ${from.label} to ${to.label}. Saved: ${result.handoff_file}`
+						);
+					} catch (error) {
+						vscode.window.showErrorMessage(`Handoff failed: ${error}`);
+					}
+				}
+			);
 		})
 	);
 
-	// Copy Handoff
 	context.subscriptions.push(
 		vscode.commands.registerCommand('relay.copyHandoff', async () => {
-			try {
-				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-				const command = relayClient.buildCopyHandoffCommand(projectDir);
-				openTerminalWithCommand(command, 'Relay: Copy Handoff');
-			} catch (error) {
-				vscode.window.showErrorMessage(`Error: ${error}`);
-			}
+			openTerminal(relayClient.buildCopyHandoffCommand(projectDir()), 'Relay: Copy Handoff');
 		})
 	);
 
-	// Status
 	context.subscriptions.push(
 		vscode.commands.registerCommand('relay.showStatus', async () => {
-			try {
-				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-				const command = relayClient.buildStatusCommand(projectDir);
-				openTerminalWithCommand(command, 'Relay: Status');
-			} catch (error) {
-				vscode.window.showErrorMessage(`Error: ${error}`);
-			}
+			openTerminal(relayClient.buildStatusCommand(projectDir()), 'Relay: Status');
 		})
 	);
 
-	// History
 	context.subscriptions.push(
 		vscode.commands.registerCommand('relay.history', async () => {
-			try {
-				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-				const command = relayClient.buildHistoryCommand(10, projectDir);
-				openTerminalWithCommand(command, 'Relay: History');
-			} catch (error) {
-				vscode.window.showErrorMessage(`Error: ${error}`);
-			}
+			openTerminal(relayClient.buildHistoryCommand(10, projectDir()), 'Relay: History');
 		})
 	);
 
-	// View Diff
 	context.subscriptions.push(
 		vscode.commands.registerCommand('relay.viewDiff', async () => {
-			try {
-				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-				const command = relayClient.buildDiffCommand(projectDir);
-				openTerminalWithCommand(command, 'Relay: Diff');
-			} catch (error) {
-				vscode.window.showErrorMessage(`Error: ${error}`);
-			}
+			openTerminal(relayClient.buildDiffCommand(projectDir()), 'Relay: Diff');
 		})
 	);
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,137 @@
+import * as vscode from 'vscode';
+import { RelayClient } from './relayClient';
+
+// Known agent/code-assistant extensions
+const AGENT_EXTENSIONS = [
+	{ id: 'github.copilot-chat', name: 'GitHub Copilot Chat' },
+	{ id: 'google.geminicodeassist', name: 'Google Gemini Code Assist' },
+	{ id: 'Codeium.codeium', name: 'Codeium' },
+	{ id: 'aws.amazonq', name: 'Amazon Q' },
+	{ id: 'TabNine.tabnine', name: 'Tabnine' },
+	{ id: 'continue.continue', name: 'Continue' },
+	{ id: 'supermaven.supermaven', name: 'Supermaven' },
+];
+
+function getInstalledAgentExtensions(): typeof AGENT_EXTENSIONS {
+	return AGENT_EXTENSIONS.filter(agent => {
+		const ext = vscode.extensions.getExtension(agent.id);
+		return ext !== undefined;
+	});
+}
+
+export async function activate(context: vscode.ExtensionContext) {
+	console.log('Relay extension activating...');
+
+	// Initialize relay client (just for building commands, no execution)
+	const relayClient = new RelayClient('relay');
+
+	// Create status bar item
+	const statusBarItem = vscode.window.createStatusBarItem(
+		vscode.StatusBarAlignment.Left,
+		100
+	);
+	statusBarItem.command = 'relay.showStatus';
+	statusBarItem.text = '⚡ Relay';
+	statusBarItem.show();
+	context.subscriptions.push(statusBarItem);
+
+	// Register commands
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.handoff', async () => {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+			// Get installed VS Code extensions that are agent/code-assistant extensions
+			const agentExtensions = getInstalledAgentExtensions();
+
+			if (agentExtensions.length === 0) {
+				vscode.window.showWarningMessage('No agent extensions found. Install Copilot, Gemini, or similar.');
+				return;
+			}
+
+			interface AgentQuickPick extends vscode.QuickPickItem {
+				extensionId: string;
+			}
+
+			const items: AgentQuickPick[] = agentExtensions.map(ext => ({
+				label: ext.name,
+				extensionId: ext.id,
+				description: 'Ready to receive handoff',
+			}));
+
+			const selected = await vscode.window.showQuickPick(items, {
+				placeHolder: 'Select agent extension to handoff to',
+				title: 'Relay Handoff',
+			});
+
+			if (!selected) {
+				return;
+			}
+
+			try {
+				// Build and execute handoff command
+				const command = relayClient.buildHandoffCommand(selected.extensionId, projectDir);
+				const terminal = vscode.window.createTerminal(`Relay → ${selected.label}`);
+				terminal.sendText(command);
+				terminal.show();
+
+				// Activate the target extension
+				const targetExt = vscode.extensions.getExtension(selected.extensionId);
+				if (targetExt && !targetExt.isActive) {
+					await targetExt.activate();
+				}
+
+				vscode.window.showInformationMessage(
+					`Handoff ready! Content copied to clipboard. Paste in ${selected.label} to continue the session.`
+				);
+			} catch (error) {
+				vscode.window.showErrorMessage(`Handoff failed: ${error}`);
+			}
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.showStatus', async () => {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			const command = relayClient.buildStatusCommand(projectDir);
+			const terminal = vscode.window.createTerminal('Relay: Status');
+			terminal.sendText(command);
+			terminal.show();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.copyHandoff', async () => {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			const command = relayClient.buildCopyHandoffCommand(projectDir);
+			const terminal = vscode.window.createTerminal('Relay: Copy Handoff');
+			terminal.sendText(command);
+			terminal.show();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.history', async () => {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			const command = relayClient.buildHistoryCommand(10, projectDir);
+			const terminal = vscode.window.createTerminal('Relay: History');
+			terminal.sendText(command);
+			terminal.show();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('relay.viewDiff', async () => {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			const command = relayClient.buildDiffCommand(projectDir);
+			const terminal = vscode.window.createTerminal('Relay: Diff');
+			terminal.sendText(command);
+			terminal.show();
+		})
+	);
+
+	console.log('Relay extension activated successfully');
+}
+
+export function deactivate() {
+	console.log('Relay extension deactivating...');
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,137 +1,23 @@
 import * as vscode from 'vscode';
 import { RelayClient } from './relayClient';
-
-// Known agent/code-assistant extensions
-const AGENT_EXTENSIONS = [
-	{ id: 'github.copilot-chat', name: 'GitHub Copilot Chat' },
-	{ id: 'google.geminicodeassist', name: 'Google Gemini Code Assist' },
-	{ id: 'Codeium.codeium', name: 'Codeium' },
-	{ id: 'aws.amazonq', name: 'Amazon Q' },
-	{ id: 'TabNine.tabnine', name: 'Tabnine' },
-	{ id: 'continue.continue', name: 'Continue' },
-	{ id: 'supermaven.supermaven', name: 'Supermaven' },
-];
-
-function getInstalledAgentExtensions(): typeof AGENT_EXTENSIONS {
-	return AGENT_EXTENSIONS.filter(agent => {
-		const ext = vscode.extensions.getExtension(agent.id);
-		return ext !== undefined;
-	});
-}
+import { registerCommands } from './commands';
+import { SessionPanelProvider } from './views/sessionPanel';
 
 export async function activate(context: vscode.ExtensionContext) {
-	console.log('Relay extension activating...');
-
-	// Initialize relay client (just for building commands, no execution)
 	const relayClient = new RelayClient('relay');
 
-	// Create status bar item
-	const statusBarItem = vscode.window.createStatusBarItem(
-		vscode.StatusBarAlignment.Left,
-		100
-	);
+	const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 	statusBarItem.command = 'relay.showStatus';
 	statusBarItem.text = '⚡ Relay';
 	statusBarItem.show();
 	context.subscriptions.push(statusBarItem);
 
-	// Register commands
+	const sessionPanel = new SessionPanelProvider(context.extensionUri, relayClient);
 	context.subscriptions.push(
-		vscode.commands.registerCommand('relay.handoff', async () => {
-			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-
-			// Get installed VS Code extensions that are agent/code-assistant extensions
-			const agentExtensions = getInstalledAgentExtensions();
-
-			if (agentExtensions.length === 0) {
-				vscode.window.showWarningMessage('No agent extensions found. Install Copilot, Gemini, or similar.');
-				return;
-			}
-
-			interface AgentQuickPick extends vscode.QuickPickItem {
-				extensionId: string;
-			}
-
-			const items: AgentQuickPick[] = agentExtensions.map(ext => ({
-				label: ext.name,
-				extensionId: ext.id,
-				description: 'Ready to receive handoff',
-			}));
-
-			const selected = await vscode.window.showQuickPick(items, {
-				placeHolder: 'Select agent extension to handoff to',
-				title: 'Relay Handoff',
-			});
-
-			if (!selected) {
-				return;
-			}
-
-			try {
-				// Build and execute handoff command
-				const command = relayClient.buildHandoffCommand(selected.extensionId, projectDir);
-				const terminal = vscode.window.createTerminal(`Relay → ${selected.label}`);
-				terminal.sendText(command);
-				terminal.show();
-
-				// Activate the target extension
-				const targetExt = vscode.extensions.getExtension(selected.extensionId);
-				if (targetExt && !targetExt.isActive) {
-					await targetExt.activate();
-				}
-
-				vscode.window.showInformationMessage(
-					`Handoff ready! Content copied to clipboard. Paste in ${selected.label} to continue the session.`
-				);
-			} catch (error) {
-				vscode.window.showErrorMessage(`Handoff failed: ${error}`);
-			}
-		})
+		vscode.window.registerTreeDataProvider('relay.sessionPanel', sessionPanel)
 	);
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand('relay.showStatus', async () => {
-			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-			const command = relayClient.buildStatusCommand(projectDir);
-			const terminal = vscode.window.createTerminal('Relay: Status');
-			terminal.sendText(command);
-			terminal.show();
-		})
-	);
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand('relay.copyHandoff', async () => {
-			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-			const command = relayClient.buildCopyHandoffCommand(projectDir);
-			const terminal = vscode.window.createTerminal('Relay: Copy Handoff');
-			terminal.sendText(command);
-			terminal.show();
-		})
-	);
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand('relay.history', async () => {
-			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-			const command = relayClient.buildHistoryCommand(10, projectDir);
-			const terminal = vscode.window.createTerminal('Relay: History');
-			terminal.sendText(command);
-			terminal.show();
-		})
-	);
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand('relay.viewDiff', async () => {
-			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-			const command = relayClient.buildDiffCommand(projectDir);
-			const terminal = vscode.window.createTerminal('Relay: Diff');
-			terminal.sendText(command);
-			terminal.show();
-		})
-	);
-
-	console.log('Relay extension activated successfully');
+	registerCommands(context, relayClient);
 }
 
-export function deactivate() {
-	console.log('Relay extension deactivating...');
-}
+export function deactivate() {}

--- a/vscode-extension/src/relayClient.ts
+++ b/vscode-extension/src/relayClient.ts
@@ -1,0 +1,192 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface SessionSnapshot {
+	current_task: string;
+	todos: { content: string; status: string }[];
+	decisions: string[];
+	last_error: string | null;
+	last_output: string | null;
+	git_state: {
+		branch: string;
+		status_summary: string;
+		recent_commits: string[];
+		diff_summary: string;
+		uncommitted_files: string[];
+	} | null;
+	project_dir: string;
+	recent_files: string[];
+	timestamp: string;
+	deadline: string | null;
+	conversation: { role: string; content: string }[];
+}
+
+export interface HandoffEntry {
+	filename: string;
+	timestamp: string;
+	agent: string;
+	task: string;
+}
+
+export interface AgentStatus {
+	name: string;
+	available: boolean;
+	reason: string;
+	version: string | null;
+}
+
+export class RelayClient {
+	private binaryPath: string;
+
+	constructor(binaryPath: string = 'relay') {
+		this.binaryPath = binaryPath;
+	}
+
+	private normalizePath(path: string): string {
+		// Convert backslashes to forward slashes for cross-platform compatibility
+		return path.replace(/\\/g, '/');
+	}
+
+	async isAvailable(): Promise<boolean> {
+		try {
+			await this.exec(['--version']);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async getStatus(projectDir?: string): Promise<SessionSnapshot> {
+		const args = ['status', '--json'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return JSON.parse(output);
+	}
+
+	async getAgents(projectDir?: string): Promise<AgentStatus[]> {
+		const args = ['agents', '--json'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return JSON.parse(output);
+	}
+
+	async handoff(
+		agent: string,
+		projectDir?: string,
+		template: string = 'full'
+	): Promise<string> {
+		const args = ['handoff', '--to', agent, '--template', template];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return output;
+	}
+
+	async copyHandoff(projectDir?: string): Promise<void> {
+		const args = ['handoff', '--clipboard'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		await this.exec(args);
+	}
+
+	async getHistory(limit: number = 10, projectDir?: string): Promise<HandoffEntry[]> {
+		const args = ['history', '--limit', limit.toString(), '--json'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return JSON.parse(output);
+	}
+
+	async getDiff(projectDir?: string): Promise<string> {
+		const args = ['diff', '--json'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return output;
+	}
+
+	buildHandoffCommand(agent: string, projectDir?: string, template: string = 'full'): string {
+		const args = ['handoff', '--to', agent, '--template', template, '--clipboard'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		return this.buildCommand(args);
+	}
+
+	buildCopyHandoffCommand(projectDir?: string): string {
+		const args = ['handoff', '--clipboard'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		return this.buildCommand(args);
+	}
+
+	buildStatusCommand(projectDir?: string): string {
+		const args = ['status'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		return this.buildCommand(args);
+	}
+
+	buildHistoryCommand(limit: number = 10, projectDir?: string): string {
+		const args = ['history', '--limit', limit.toString()];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		return this.buildCommand(args);
+	}
+
+	buildDiffCommand(projectDir?: string): string {
+		const args = ['diff'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		return this.buildCommand(args);
+	}
+
+	private buildCommand(args: string[]): string {
+		const argsStr = args
+			.map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+			.join(' ');
+		let binaryPath = this.binaryPath;
+		if (process.platform === 'win32' && binaryPath.includes('\\')) {
+			binaryPath = `"${binaryPath}"`;
+		}
+		return `${binaryPath} ${argsStr}`;
+	}
+
+	private async exec(args: string[]): Promise<string> {
+		try {
+			// Build command with proper quoting for arguments
+			const argsStr = args
+				.map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+				.join(' ');
+
+			// Quote binary path on Windows with backslashes
+			let binaryPath = this.binaryPath;
+			if (process.platform === 'win32' && binaryPath.includes('\\')) {
+				binaryPath = `"${binaryPath}"`;
+			}
+
+			const cmd = `${binaryPath} ${argsStr}`;
+			console.log(`Executing: ${cmd}`);
+
+			const { stdout } = await execAsync(cmd);
+			return stdout.trim();
+		} catch (error) {
+			console.error(`Relay exec error: ${error}`);
+			throw error;
+		}
+	}
+}

--- a/vscode-extension/src/relayClient.ts
+++ b/vscode-extension/src/relayClient.ts
@@ -115,6 +115,15 @@ export class RelayClient {
 		return output;
 	}
 
+	async getHandoffText(agent: string, projectDir?: string, template: string = 'full'): Promise<{ handoff_text: string; handoff_file: string }> {
+		const args = ['handoff', '--to', agent, '--template', template, '--json'];
+		if (projectDir) {
+			args.push('--project', this.normalizePath(projectDir));
+		}
+		const output = await this.exec(args);
+		return JSON.parse(output);
+	}
+
 	buildHandoffCommand(agent: string, projectDir?: string, template: string = 'full'): string {
 		const args = ['handoff', '--to', agent, '--template', template, '--clipboard'];
 		if (projectDir) {

--- a/vscode-extension/src/views/sessionPanel.ts
+++ b/vscode-extension/src/views/sessionPanel.ts
@@ -1,0 +1,181 @@
+import * as vscode from 'vscode';
+import { RelayClient, SessionSnapshot, AgentStatus } from '../relayClient';
+
+export class SessionPanelProvider implements vscode.TreeDataProvider<SessionItem> {
+	private _onDidChangeTreeData: vscode.EventEmitter<SessionItem | undefined | null | void> =
+		new vscode.EventEmitter<SessionItem | undefined | null | void>();
+	readonly onDidChangeTreeData: vscode.Event<SessionItem | undefined | null | void> =
+		this._onDidChangeTreeData.event;
+
+	private sessionSnapshot: SessionSnapshot | null = null;
+	private agents: AgentStatus[] = [];
+
+	constructor(
+		private extensionUri: vscode.Uri,
+		private relayClient: RelayClient
+	) {
+		this.refresh();
+	}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire();
+		this.loadSession();
+	}
+
+	private async loadSession(): Promise<void> {
+		try {
+			const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+			this.sessionSnapshot = await this.relayClient.getStatus(projectDir);
+			this.agents = await this.relayClient.getAgents(projectDir);
+		} catch (error) {
+			console.error('Failed to load session:', error);
+		}
+	}
+
+	getTreeItem(element: SessionItem): vscode.TreeItem {
+		return element;
+	}
+
+	async getChildren(element?: SessionItem): Promise<SessionItem[]> {
+		if (!this.sessionSnapshot) {
+			return [];
+		}
+
+		if (!element) {
+			// Root items
+			return [
+				new SessionItem(
+					'Task',
+					`${this.sessionSnapshot.current_task.substring(0, 50)}...`,
+					vscode.TreeItemCollapsibleState.None,
+					'task'
+				),
+				new SessionItem(
+					'Project',
+					this.sessionSnapshot.project_dir.split('/').pop() || 'unknown',
+					vscode.TreeItemCollapsibleState.None,
+					'project'
+				),
+				...(this.sessionSnapshot.git_state
+					? [
+						new SessionItem(
+							'Git',
+							`${this.sessionSnapshot.git_state.branch} (${this.sessionSnapshot.git_state.status_summary})`,
+							vscode.TreeItemCollapsibleState.Collapsed,
+							'git'
+						),
+					]
+					: []),
+				new SessionItem(
+					'Agents',
+					`${this.agents.filter((a) => a.available).length}/${this.agents.length} available`,
+					vscode.TreeItemCollapsibleState.Collapsed,
+					'agents'
+				),
+				new SessionItem(
+					'Handoff',
+					'Click to handoff',
+					vscode.TreeItemCollapsibleState.None,
+					'handoff',
+					'relay.handoff'
+				),
+			];
+		}
+
+		// Git details
+		if (element.id === 'git' && this.sessionSnapshot.git_state) {
+			return [
+				new SessionItem(
+					'Branch',
+					this.sessionSnapshot.git_state.branch,
+					vscode.TreeItemCollapsibleState.None,
+					'git-branch'
+				),
+				new SessionItem(
+					'Status',
+					this.sessionSnapshot.git_state.status_summary,
+					vscode.TreeItemCollapsibleState.None,
+					'git-status'
+				),
+				...(this.sessionSnapshot.git_state.recent_commits.length > 0
+					? [
+						new SessionItem(
+							'Recent Commits',
+							'',
+							vscode.TreeItemCollapsibleState.Collapsed,
+							'git-commits'
+						),
+					]
+					: []),
+			];
+		}
+
+		// Recent commits
+		if (element.id === 'git-commits' && this.sessionSnapshot.git_state) {
+			return this.sessionSnapshot.git_state.recent_commits.map(
+				(commit) =>
+					new SessionItem(commit, '', vscode.TreeItemCollapsibleState.None, 'commit')
+			);
+		}
+
+		// Agents - Show VS Code extensions instead
+		if (element.id === 'agents') {
+			const agentExtensions = [
+				{ id: 'github.copilot-chat', name: 'GitHub Copilot Chat' },
+				{ id: 'google.geminicodeassist', name: 'Google Gemini Code Assist' },
+				{ id: 'Codeium.codeium', name: 'Codeium' },
+				{ id: 'aws.amazonq', name: 'Amazon Q' },
+				{ id: 'TabNine.tabnine', name: 'Tabnine' },
+				{ id: 'continue.continue', name: 'Continue' },
+				{ id: 'supermaven.supermaven', name: 'Supermaven' },
+			];
+
+			const installed = agentExtensions.filter(agent => {
+				const ext = vscode.extensions.getExtension(agent.id);
+				return ext !== undefined;
+			});
+
+			return installed.length > 0
+				? installed.map(
+					(agent) =>
+						new SessionItem(
+							agent.name,
+							'✓ Ready',
+							vscode.TreeItemCollapsibleState.None,
+							'agent',
+							'relay.handoff'
+						)
+				)
+				: [
+					new SessionItem(
+						'No agent extensions found',
+						'Install Copilot, Gemini, or similar',
+						vscode.TreeItemCollapsibleState.None,
+						'agent'
+					),
+				];
+		}
+
+		return [];
+	}
+}
+
+class SessionItem extends vscode.TreeItem {
+	constructor(
+		public readonly label: string,
+		public readonly description: string,
+		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+		public readonly id: string,
+		commandId?: string
+	) {
+		super(label, collapsibleState);
+		this.description = description;
+		if (commandId) {
+			this.command = {
+				command: commandId,
+				title: label,
+				arguments: [],
+			} as vscode.Command;
+		}
+	}
+}

--- a/vscode-extension/src/views/sessionPanel.ts
+++ b/vscode-extension/src/views/sessionPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { RelayClient, SessionSnapshot, AgentStatus } from '../relayClient';
+import { RelayClient, SessionSnapshot } from '../relayClient';
+import { getInstalledAgents } from '../agents/registry';
 
 export class SessionPanelProvider implements vscode.TreeDataProvider<SessionItem> {
 	private _onDidChangeTreeData: vscode.EventEmitter<SessionItem | undefined | null | void> =
@@ -8,7 +9,7 @@ export class SessionPanelProvider implements vscode.TreeDataProvider<SessionItem
 		this._onDidChangeTreeData.event;
 
 	private sessionSnapshot: SessionSnapshot | null = null;
-	private agents: AgentStatus[] = [];
+	private agents: { name: string; available: boolean; reason: string }[] = [];
 
 	constructor(
 		private extensionUri: vscode.Uri,
@@ -118,42 +119,11 @@ export class SessionPanelProvider implements vscode.TreeDataProvider<SessionItem
 			);
 		}
 
-		// Agents - Show VS Code extensions instead
 		if (element.id === 'agents') {
-			const agentExtensions = [
-				{ id: 'github.copilot-chat', name: 'GitHub Copilot Chat' },
-				{ id: 'google.geminicodeassist', name: 'Google Gemini Code Assist' },
-				{ id: 'Codeium.codeium', name: 'Codeium' },
-				{ id: 'aws.amazonq', name: 'Amazon Q' },
-				{ id: 'TabNine.tabnine', name: 'Tabnine' },
-				{ id: 'continue.continue', name: 'Continue' },
-				{ id: 'supermaven.supermaven', name: 'Supermaven' },
-			];
-
-			const installed = agentExtensions.filter(agent => {
-				const ext = vscode.extensions.getExtension(agent.id);
-				return ext !== undefined;
-			});
-
+			const installed = getInstalledAgents();
 			return installed.length > 0
-				? installed.map(
-					(agent) =>
-						new SessionItem(
-							agent.name,
-							'✓ Ready',
-							vscode.TreeItemCollapsibleState.None,
-							'agent',
-							'relay.handoff'
-						)
-				)
-				: [
-					new SessionItem(
-						'No agent extensions found',
-						'Install Copilot, Gemini, or similar',
-						vscode.TreeItemCollapsibleState.None,
-						'agent'
-					),
-				];
+				? installed.map(a => new SessionItem(a.name, a.autoTrigger ? '✓ Auto' : '⎘ Clipboard', vscode.TreeItemCollapsibleState.None, 'agent', 'relay.handoff'))
+				: [new SessionItem('No agent extensions found', 'Install Copilot, Gemini, or similar', vscode.TreeItemCollapsibleState.None, 'agent')];
 		}
 
 		return [];

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a VS Code extension that enables cross-agent session handoffs directly within the editor. Users can transfer context from one AI coding assistant to another (e.g., Claude Code → Gemini Code Assist) without leaving VS Code.

**Key features:**
- Sidebar panel showing current session state (task, project, git info, available agents)
- 2-step handoff flow: pick source agent → pick target agent
- Auto-trigger for extensions using VS Code's Chat Participant API (Copilot, Gemini, Claude Code, Cline, Continue, etc.)
- Clipboard fallback for sealed webview extensions (Codex, Blackbox AI)
- Case-insensitive extension discovery across 23 supported agents
- Status bar item for quick access
- Relay CLI integration via RelayClient wrapper with cross-platform path handling

## Type of change

- [x] New feature

## Checklist

- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [ ] Updated README if needed
